### PR TITLE
Implement ability to specify primitive types from the command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,9 +135,12 @@ $ mj user.name=Bob user.age:int=25 user.verified:bool=true
 {"user":{"age":25,"name":"Bob","verified":true}}
 
 # Arrays with types: the [] come before the type suffix.
-# The type must be consistent across all elements.
 $ mj scores[]:int=95 scores[]:int=87 scores[]:int=92
 {"scores":[95,87,92]}
+
+# Arrays can also hold mixed types
+$ mj items[]=apple items[]=42 items[]=true items[]=null
+{"items":["apple",42,true,null]}
 ```
 
 Use the `-t` flag to change the type separator (default `:`):

--- a/README.md
+++ b/README.md
@@ -86,10 +86,83 @@ $ mj foo=@bar.txt
 {"foo":"@bar.txt"}
 ```
 
-However, you can designate certain prefixes to read values from a file:
+However, you can designate certain prefixes to read values from a file,
+using the `-r` flag. The default prefix is blank, which disables file reading,
+as shown above.
 
 ```shell
 $ echo hello-world > bar.txt
 $ mj -r=@ foo=@bar.txt
 {"foo":"hello-world\n"}
 ```
+
+By default, all values are treated as strings. Use type suffixes to create other JSON primitives:
+
+- `:string` - String value (default, can be omitted)
+- `:int` - Integer number
+- `:float` - Floating-point number
+- `:bool` - Boolean (`true`/`false`, `1`/`0`)
+- `:null` - Null value (value part ignored)
+
+```shell
+# Numbers
+$ mj age:int=25
+{"age":25}
+
+$ mj price:float=19.99
+{"price":19.99}
+
+$ mj temp:int=-10
+{"temp":-10}
+
+# Booleans
+$ mj active:bool=true
+{"active":true}
+
+$ mj deleted:bool=false
+{"deleted":false}
+
+# Null
+$ mj value:null=
+{"value":null}
+
+# Mixed types
+$ mj name=Alice age:int=30 premium:bool=true
+{"age":30,"name":"Alice","premium":true}
+
+# With nested objects
+$ mj user.name=Bob user.age:int=25 user.verified:bool=true
+{"user":{"age":25,"name":"Bob","verified":true}}
+
+# Arrays with types
+$ mj scores:int[]=95 scores:int[]=87 scores:int[]=92
+{"scores":[95,87,92]}
+```
+
+Use the `-t` flag to change the type separator (default `:`):
+
+```shell
+$ mj -t=/ age/int=25
+{"age":25}
+```
+
+This is useful when your keys contain colons:
+
+```shell
+$ mj -t=/ "url:port"=8080 "url:host"=localhost
+{"url:host":"localhost","url:port":"8080"}
+
+$ mj -t=/ url:port/int=8080 url:host=localhost
+{"url:host":"localhost","url:port":8080}
+```
+
+Invalid values for typed fields will produce errors:
+
+```shell
+$ mj age:int=not-a-number
+Error: cannot parse "not-a-number" as int
+
+$ mj active:bool=maybe
+Error: cannot parse "maybe" as bool
+```
+

--- a/README.md
+++ b/README.md
@@ -115,14 +115,14 @@ $ mj price:float=19.99
 $ mj temp:int=-10
 {"temp":-10}
 
-# Booleans
+# Booleans take True/T/t/true False/F/f/false or 1/0
 $ mj active:bool=true
 {"active":true}
 
 $ mj deleted:bool=false
 {"deleted":false}
 
-# Null
+# Nulls must have no value
 $ mj value:null=
 {"value":null}
 
@@ -134,7 +134,8 @@ $ mj name=Alice age:int=30 premium:bool=true
 $ mj user.name=Bob user.age:int=25 user.verified:bool=true
 {"user":{"age":25,"name":"Bob","verified":true}}
 
-# Arrays with types
+# Arrays with types: the [] come before the type suffix.
+# The type must be consistent across all elements.
 $ mj scores[]:int=95 scores[]:int=87 scores[]:int=92
 {"scores":[95,87,92]}
 ```

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ $ mj user.name=Bob user.age:int=25 user.verified:bool=true
 {"user":{"age":25,"name":"Bob","verified":true}}
 
 # Arrays with types
-$ mj scores:int[]=95 scores:int[]=87 scores:int[]=92
+$ mj scores[]:int=95 scores[]:int=87 scores[]:int=92
 {"scores":[95,87,92]}
 ```
 

--- a/pkg/mj/app.go
+++ b/pkg/mj/app.go
@@ -37,11 +37,24 @@ func usage() {
 
   mj foo=bar | mj baz=quux	{"baz":"quux"}
   mj foo=bar | mj -m=- baz=quux	{"baz":"quux","foo":"bar"}
+
+Type suffixes:
+  mj age:int=25			{"age":25}
+  mj price:float=19.99		{"price":19.99}
+  mj active:bool=true		{"active":true}
+  mj deleted:null=		{"deleted":null}
+  mj name:string=Alice		{"name":"Alice"}
+  mj name=Alice			{"name":"Alice"} (default is string)
+  
+  mj scores:int[]=95 scores:int[]=87	{"scores":[95,87]}
+  mj user.age:int=25 user.name=Bob	{"user":{"age":25,"name":"Bob"}}
+  
+  mj -t=/ age/int=25		{"age":25} (custom separator)
   `)
 }
 
 func Run() int {
-	var kvSeparator, pathSeparator string
+	var kvSeparator, pathSeparator, typeSeparator string
 	var readFilePrefix, readFrom string
 	var showVersion bool
 
@@ -50,6 +63,7 @@ func Run() int {
 	flag.StringVar(&kvSeparator, "s", "=", "Separator between key and value")
 	flag.StringVar(&pathSeparator, "p", ".", "Separator between key-path components")
 	flag.StringVar(&readFilePrefix, "r", "", "Prefix (for values) that indicate reading from a local file; reading value from a file is disabled when this flag is empty (default empty)")
+	flag.StringVar(&typeSeparator, "t", ":", "Separator between key and type suffix")
 	flag.BoolVar(&showVersion, "version", false, "Show version")
 	flag.Parse()
 
@@ -87,6 +101,7 @@ func Run() int {
 		KeyValueSeparator: kvSeparator,
 		KeyPathSeparator:  pathSeparator,
 		ReadFilePrefix:    readFilePrefix,
+		TypeSeparator:     typeSeparator,
 	}
 
 	for i, arg := range flag.Args() {

--- a/pkg/mj/app.go
+++ b/pkg/mj/app.go
@@ -38,7 +38,6 @@ func usage() {
   mj foo=bar | mj baz=quux	{"baz":"quux"}
   mj foo=bar | mj -m=- baz=quux	{"baz":"quux","foo":"bar"}
 
-Type suffixes:
   mj age:int=25			{"age":25}
   mj price:float=19.99		{"price":19.99}
   mj active:bool=true		{"active":true}
@@ -46,7 +45,7 @@ Type suffixes:
   mj name:string=Alice		{"name":"Alice"}
   mj name=Alice			{"name":"Alice"} (default is string)
   
-  mj scores:int[]=95 scores:int[]=87	{"scores":[95,87]}
+  mj scores[]:int=95 scores[]:int=87	{"scores":[95,87]}
   mj user.age:int=25 user.name=Bob	{"user":{"age":25,"name":"Bob"}}
   
   mj -t=/ age/int=25		{"age":25} (custom separator)

--- a/pkg/mj/app_test.go
+++ b/pkg/mj/app_test.go
@@ -1,14 +1,16 @@
 package mj
 
 import (
-	"github.com/rogpeppe/go-internal/testscript"
+	"os"
 	"testing"
+
+	"github.com/rogpeppe/go-internal/testscript"
 )
 
 func TestMain(m *testing.M) {
 	testscript.Main(m, map[string]func(){
 		"mj": func() {
-			_ = Run()
+			os.Exit(Run())
 		},
 	})
 }

--- a/pkg/mj/processor.go
+++ b/pkg/mj/processor.go
@@ -65,18 +65,27 @@ func (p *Processor) parseTypeSuffix(key string) (string, ValueType) {
 func parseTypedValue(value string, vtype ValueType) (interface{}, error) {
 	switch vtype {
 	case TypeInt:
+		if value == "" {
+			return 0, nil
+		}
 		v, err := strconv.ParseInt(value, 10, 64)
 		if err != nil {
 			return nil, fmt.Errorf("cannot parse %q as int: %w", value, err)
 		}
 		return v, nil
 	case TypeFloat:
+		if value == "" {
+			return 0.0, nil
+		}
 		v, err := strconv.ParseFloat(value, 64)
 		if err != nil {
 			return nil, fmt.Errorf("cannot parse %q as float: %w", value, err)
 		}
 		return v, nil
 	case TypeBool:
+		if value == "" {
+			return false, nil
+		}
 		v, err := strconv.ParseBool(value)
 		if err != nil {
 			return nil, fmt.Errorf("cannot parse %q as bool: %w", value, err)

--- a/pkg/mj/processor.go
+++ b/pkg/mj/processor.go
@@ -3,7 +3,18 @@ package mj
 import (
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
+)
+
+type ValueType int
+
+const (
+	TypeString ValueType = iota
+	TypeInt
+	TypeFloat
+	TypeBool
+	TypeNull
 )
 
 type Processor struct {
@@ -11,10 +22,73 @@ type Processor struct {
 	KeyValueSeparator string
 	KeyPathSeparator  string
 	ReadFilePrefix    string
+	TypeSeparator     string
 }
 
 func (p *Processor) Output() Struct {
 	return p.Input
+}
+
+// parseTypeSuffix extracts type from key like "age:int" -> ("age", TypeInt)
+func (p *Processor) parseTypeSuffix(key string) (string, ValueType) {
+	if p.TypeSeparator == "" {
+		return key, TypeString
+	}
+
+	// Find the last occurrence of TypeSeparator to handle keys with multiple separators
+	lastIdx := strings.LastIndex(key, p.TypeSeparator)
+	if lastIdx == -1 {
+		return key, TypeString
+	}
+
+	suffix := key[lastIdx+len(p.TypeSeparator):]
+	cleanKey := key[:lastIdx]
+
+	switch suffix {
+	case "int":
+		return cleanKey, TypeInt
+	case "float":
+		return cleanKey, TypeFloat
+	case "bool":
+		return cleanKey, TypeBool
+	case "null":
+		return cleanKey, TypeNull
+	case "string":
+		return cleanKey, TypeString
+	default:
+		// Not a recognized type suffix, treat the whole thing as the key
+		return key, TypeString
+	}
+}
+
+// parseTypedValue converts string value to appropriate type
+func parseTypedValue(value string, vtype ValueType) (interface{}, error) {
+	switch vtype {
+	case TypeInt:
+		v, err := strconv.ParseInt(value, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("cannot parse %q as int: %w", value, err)
+		}
+		return v, nil
+	case TypeFloat:
+		v, err := strconv.ParseFloat(value, 64)
+		if err != nil {
+			return nil, fmt.Errorf("cannot parse %q as float: %w", value, err)
+		}
+		return v, nil
+	case TypeBool:
+		v, err := strconv.ParseBool(value)
+		if err != nil {
+			return nil, fmt.Errorf("cannot parse %q as bool: %w", value, err)
+		}
+		return v, nil
+	case TypeNull:
+		return nil, nil
+	case TypeString:
+		return value, nil
+	default:
+		return value, nil
+	}
 }
 
 func (p *Processor) Process(arg string) error {
@@ -23,9 +97,27 @@ func (p *Processor) Process(arg string) error {
 		return fmt.Errorf("missing separator (%q) in %q", p.KeyValueSeparator, arg)
 	}
 
-	keyPath := strings.Split(segments[0], p.KeyPathSeparator)
+	keyPathStr := segments[0]
 	value := segments[1]
 
+	// Check for array syntax before splitting the path
+	isArray := strings.HasSuffix(keyPathStr, "[]")
+	if isArray {
+		keyPathStr = strings.TrimSuffix(keyPathStr, "[]")
+	}
+
+	// Parse type suffix from the key (after removing array syntax)
+	keyPathStr, vtype := p.parseTypeSuffix(keyPathStr)
+
+	// Now split the path
+	keyPath := strings.Split(keyPathStr, p.KeyPathSeparator)
+
+	// Restore array syntax to the last key component if needed
+	if isArray {
+		keyPath = append(keyPath, "[]")
+	}
+
+	// Handle file reading
 	if p.ReadFilePrefix != "" && strings.HasPrefix(value, p.ReadFilePrefix) {
 		fn := strings.TrimPrefix(value, p.ReadFilePrefix)
 		v, err := os.ReadFile(fn)
@@ -35,5 +127,11 @@ func (p *Processor) Process(arg string) error {
 		value = string(v)
 	}
 
-	return p.Input.Set(keyPath, value)
+	// Parse the value according to its type
+	typedValue, err := parseTypedValue(value, vtype)
+	if err != nil {
+		return err
+	}
+
+	return p.Input.Set(keyPath, typedValue)
 }

--- a/pkg/mj/processor.go
+++ b/pkg/mj/processor.go
@@ -100,24 +100,9 @@ func (p *Processor) Process(arg string) error {
 	keyPathStr := segments[0]
 	value := segments[1]
 
-	// Check for array syntax before splitting the path
-	isArray := strings.HasSuffix(keyPathStr, "[]")
-	if isArray {
-		keyPathStr = strings.TrimSuffix(keyPathStr, "[]")
-	}
-
-	// Parse type suffix from the key (after removing array syntax)
 	keyPathStr, vtype := p.parseTypeSuffix(keyPathStr)
-
-	// Now split the path
 	keyPath := strings.Split(keyPathStr, p.KeyPathSeparator)
 
-	// Restore array syntax to the last key component if needed
-	if isArray {
-		keyPath = append(keyPath, "[]")
-	}
-
-	// Handle file reading
 	if p.ReadFilePrefix != "" && strings.HasPrefix(value, p.ReadFilePrefix) {
 		fn := strings.TrimPrefix(value, p.ReadFilePrefix)
 		v, err := os.ReadFile(fn)
@@ -127,7 +112,6 @@ func (p *Processor) Process(arg string) error {
 		value = string(v)
 	}
 
-	// Parse the value according to its type
 	typedValue, err := parseTypedValue(value, vtype)
 	if err != nil {
 		return err

--- a/pkg/mj/processor.go
+++ b/pkg/mj/processor.go
@@ -92,6 +92,9 @@ func parseTypedValue(value string, vtype ValueType) (interface{}, error) {
 		}
 		return v, nil
 	case TypeNull:
+		if value != "" {
+			return nil, fmt.Errorf("cannot parse non-empty %q as null", value)
+		}
 		return nil, nil
 	case TypeString:
 		return value, nil

--- a/pkg/mj/testdata/scripts/arrays.txtar
+++ b/pkg/mj/testdata/scripts/arrays.txtar
@@ -13,7 +13,7 @@ cmp stdout numeric_keys.txt
 ! stderr .
 
 # TODO: array in the middle of the path is not yet supported
-exec mj foo.bar[].abc=1 foo.bar[].def=2
+! exec mj foo.bar[].abc=1 foo.bar[].def=2
 ! stdout .
 cmp stderr unsupported.txt
 

--- a/pkg/mj/testdata/scripts/error-conflict.txtar
+++ b/pkg/mj/testdata/scripts/error-conflict.txtar
@@ -1,4 +1,4 @@
-exec mj foo=bar foo=quux
+! exec mj foo=bar foo=quux
 ! stdout .
 cmp stderr conflict.txt
 

--- a/pkg/mj/testdata/scripts/types.txtar
+++ b/pkg/mj/testdata/scripts/types.txtar
@@ -103,6 +103,12 @@ stdout '{"a":{"b":{"c":1,"d":2.5,"e":"text"}}}'
 exec mj ints[]:int=1 ints[]:int=2 floats[]:float=1.5 floats[]:float=2.5 strs[]=a strs[]=b
 stdout '{"floats":\[1.5,2.5\],"ints":\[1,2\],"strs":\["a","b"\]}'
 
+exec mj mixed[]:int=1 mixed[]:float=2.5 mixed[]=text
+stdout '{"mixed":\[1,2.5,"text"\]}'
+
+exec mj items[]=apple items[]:int=42 items[]:bool=true items[]:null=
+stdout '{"items":\["apple",42,true,null\]}'
+
 # Unrecognized type suffix treated as part of key name
 exec mj age:unknown=25
 stdout '{"age:unknown":"25"}'

--- a/pkg/mj/testdata/scripts/types.txtar
+++ b/pkg/mj/testdata/scripts/types.txtar
@@ -8,8 +8,8 @@ stdout '{"price":19.99}'
 exec mj active:bool=true
 stdout '{"active":true}'
 
-exec mj value:null=ignored
-stdout '{"value":null}'
+! exec mj value:null=ignored
+stderr 'cannot parse non-empty "ignored" as null'
 
 exec mj value:null=
 stdout '{"value":null}'
@@ -49,8 +49,8 @@ stderr 'cannot parse "maybe" as bool'
 stderr 'cannot parse "yes" as bool'
 
 # Test null with any value
-exec mj a:null= b:null=anything c:null=123
-stdout '{"a":null,"b":null,"c":null}'
+! exec mj a:null= b:null=anything c:null=123
+stderr 'cannot parse non-empty "anything" as null'
 
 # Test float vs int
 exec mj exact:int=42 precise:float=42.0

--- a/pkg/mj/testdata/scripts/types.txtar
+++ b/pkg/mj/testdata/scripts/types.txtar
@@ -92,6 +92,9 @@ stdout '{"bignum":9223372036854775807}'
 exec mj zero:int=0 nada:float=0.0 nope:bool=false
 stdout '{"nada":0,"nope":false,"zero":0}'
 
+exec mj zero:int= nada:float= nope:bool=
+stdout '{"nada":0,"nope":false,"zero":0}'
+
 # Multiple nested levels with types
 exec mj a.b.c:int=1 a.b.d:float=2.5 a.b.e=text
 stdout '{"a":{"b":{"c":1,"d":2.5,"e":"text"}}}'

--- a/pkg/mj/testdata/scripts/types.txtar
+++ b/pkg/mj/testdata/scripts/types.txtar
@@ -34,16 +34,19 @@ exec mj -t=/ age/int=25 name=Alice
 stdout '{"age":25,"name":"Alice"}'
 
 # Test boolean variants
-exec mj a:bool=true b:bool=false c:bool=1 d:bool=0
-stdout '{"a":true,"b":false,"c":true,"d":false}'
+exec mj a:bool=true b:bool=false c:bool=1 d:bool=0 e:bool=t f:bool=f
+stdout '{"a":true,"b":false,"c":true,"d":false,"e":true,"f":false}'
 
 # Test invalid int value
 ! exec mj age:int=not-a-number
-stderr 'cannot parse'
+stderr 'cannot parse "not-a-number" as int'
 
 # Test invalid bool value
 ! exec mj active:bool=maybe
-stderr 'cannot parse'
+stderr 'cannot parse "maybe" as bool'
+
+! exec mj active:bool=yes
+stderr 'cannot parse "yes" as bool'
 
 # Test null with any value
 exec mj a:null= b:null=anything c:null=123

--- a/pkg/mj/testdata/scripts/types.txtar
+++ b/pkg/mj/testdata/scripts/types.txtar
@@ -26,7 +26,7 @@ exec mj user.age:int=25 user.name=Bob
 stdout '{"user":{"age":25,"name":"Bob"}}'
 
 # Test arrays with types
-exec mj scores:int[]=95 scores:int[]=87 scores:int[]=92
+exec mj scores[]:int=95 scores[]:int=87 scores[]:int=92
 stdout '{"scores":\[95,87,92\]}'
 
 # Test custom type separator
@@ -94,7 +94,7 @@ exec mj a.b.c:int=1 a.b.d:float=2.5 a.b.e=text
 stdout '{"a":{"b":{"c":1,"d":2.5,"e":"text"}}}'
 
 # Arrays of different types
-exec mj ints:int[]=1 ints:int[]=2 floats:float[]=1.5 floats:float[]=2.5 strs[]=a strs[]=b
+exec mj ints[]:int=1 ints[]:int=2 floats[]:float=1.5 floats[]:float=2.5 strs[]=a strs[]=b
 stdout '{"floats":\[1.5,2.5\],"ints":\[1,2\],"strs":\["a","b"\]}'
 
 # Unrecognized type suffix treated as part of key name

--- a/pkg/mj/testdata/scripts/types.txtar
+++ b/pkg/mj/testdata/scripts/types.txtar
@@ -1,0 +1,110 @@
+# Test basic type suffixes
+exec mj age:int=25
+stdout '{"age":25}'
+
+exec mj price:float=19.99
+stdout '{"price":19.99}'
+
+exec mj active:bool=true
+stdout '{"active":true}'
+
+exec mj value:null=ignored
+stdout '{"value":null}'
+
+exec mj value:null=
+stdout '{"value":null}'
+
+! exec mj value:null
+stderr 'missing separator \("="\) in "value:null"'
+
+# Test mixed types
+exec mj name=Alice age:int=30 score:float=95.5 active:bool=true
+stdout '{"active":true,"age":30,"name":"Alice","score":95.5}'
+
+# Test nested with types
+exec mj user.age:int=25 user.name=Bob
+stdout '{"user":{"age":25,"name":"Bob"}}'
+
+# Test arrays with types
+exec mj scores:int[]=95 scores:int[]=87 scores:int[]=92
+stdout '{"scores":\[95,87,92\]}'
+
+# Test custom type separator
+exec mj -t=/ age/int=25 name=Alice
+stdout '{"age":25,"name":"Alice"}'
+
+# Test boolean variants
+exec mj a:bool=true b:bool=false c:bool=1 d:bool=0
+stdout '{"a":true,"b":false,"c":true,"d":false}'
+
+# Test invalid int value
+! exec mj age:int=not-a-number
+stderr 'cannot parse'
+
+# Test invalid bool value
+! exec mj active:bool=maybe
+stderr 'cannot parse'
+
+# Test null with any value
+exec mj a:null= b:null=anything c:null=123
+stdout '{"a":null,"b":null,"c":null}'
+
+# Test float vs int
+exec mj exact:int=42 precise:float=42.0
+stdout '{"exact":42,"precise":42}'
+
+# Test negative numbers
+exec mj temp:int=-10 balance:float=-15.50
+stdout '{"balance":-15.5,"temp":-10}'
+
+# Test explicit string type
+exec mj name:string=Alice
+stdout '{"name":"Alice"}'
+
+# Test backward compatibility - no type means string
+exec mj foo=bar
+stdout '{"foo":"bar"}'
+
+# Type suffix should work with path separators
+exec mj foo.bar:int=42
+stdout '{"foo":{"bar":42}}'
+
+# Type suffix with custom path separator
+exec mj -p=/ foo/bar:int=42
+stdout '{"foo":{"bar":42}}'
+
+# Empty string values
+exec mj name:string= value=
+stdout '{"name":"","value":""}'
+
+# Scientific notation for floats - JSON encodes as regular numbers
+exec mj big:float=1e10 small:float=1.5e-3
+stdout '{"big":10000000000,"small":0.0015}'
+
+# Large integers
+exec mj bignum:int=9223372036854775807
+stdout '{"bignum":9223372036854775807}'
+
+# Zero values
+exec mj zero:int=0 nada:float=0.0 nope:bool=false
+stdout '{"nada":0,"nope":false,"zero":0}'
+
+# Multiple nested levels with types
+exec mj a.b.c:int=1 a.b.d:float=2.5 a.b.e=text
+stdout '{"a":{"b":{"c":1,"d":2.5,"e":"text"}}}'
+
+# Arrays of different types
+exec mj ints:int[]=1 ints:int[]=2 floats:float[]=1.5 floats:float[]=2.5 strs[]=a strs[]=b
+stdout '{"floats":\[1.5,2.5\],"ints":\[1,2\],"strs":\["a","b"\]}'
+
+# Unrecognized type suffix treated as part of key name
+exec mj age:unknown=25
+stdout '{"age:unknown":"25"}'
+
+# Keys with colon when using custom type separator
+exec mj -t=/ time:stamp=2024
+stdout '{"time:stamp":"2024"}'
+
+# Mix of custom separator and colons in key names
+exec mj -t=/ url:port/int=8080 url:host=localhost
+stdout '{"url:host":"localhost","url:port":8080}'


### PR DESCRIPTION
e.g.:

```
$ mj name=Alice age:int=30 premium:bool=true
{"age":30,"name":"Alice","premium":true}
```
